### PR TITLE
Improve integration test stability

### DIFF
--- a/frontend/tests/integration/helpers.js
+++ b/frontend/tests/integration/helpers.js
@@ -12,6 +12,26 @@ const TIMEOUTS = {
 };
 
 /**
+ * Wait for an API response matching a URL fragment and optional predicate.
+ * @param {import('@playwright/test').Page} page - Playwright page object
+ * @param {string} urlFragment - URL fragment to match
+ * @param {{ timeout?: number, predicate?: (response: import('@playwright/test').Response) => boolean }} options
+ */
+function waitForApiResponse(page, urlFragment, options = {}) {
+  const { timeout = TIMEOUTS.LONG, predicate } = options;
+
+  return page.waitForResponse(
+    (response) => {
+      if (!response.url().includes(urlFragment)) {
+        return false;
+      }
+      return predicate ? predicate(response) : true;
+    },
+    { timeout }
+  );
+}
+
+/**
  * Login to the application with given credentials
  * @param {import('@playwright/test').Page} page - Playwright page object
  * @param {string} email - User email
@@ -19,17 +39,24 @@ const TIMEOUTS = {
  */
 async function login(page, email, password) {
   // Navigate to login page
-  await page.goto('/', { waitUntil: 'networkidle', timeout: TIMEOUTS.LONG });
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: TIMEOUTS.LONG });
   
   // Wait for login form to be visible
-  await page.waitForSelector('input#email', { timeout: TIMEOUTS.MEDIUM });
+  const emailInput = page.getByLabel('Email');
+  await emailInput.waitFor({ state: 'visible', timeout: TIMEOUTS.MEDIUM });
   
   // Fill in credentials
-  await page.fill('input#email', email);
-  await page.fill('input#password', password);
+  await emailInput.fill(email);
+  await page.getByLabel('Password').fill(password);
   
   // Submit and wait for navigation
-  await page.click('button[type="submit"]');
+  const loginResponse = waitForApiResponse(page, '/api/auth/login', {
+    predicate: (response) => response.request().method() === 'POST' && response.ok(),
+  });
+  await Promise.all([
+    loginResponse,
+    page.getByRole('button', { name: 'Login' }).click(),
+  ]);
   
   // Wait for successful login - app header should appear
   await page.waitForSelector('.app-header', { timeout: TIMEOUTS.LONG });
@@ -49,5 +76,6 @@ function getAdminCredentials() {
 module.exports = {
   login,
   getAdminCredentials,
-  TIMEOUTS
+  TIMEOUTS,
+  waitForApiResponse,
 };

--- a/frontend/tests/integration/login.spec.js
+++ b/frontend/tests/integration/login.spec.js
@@ -1,5 +1,5 @@
 const { test, expect } = require('@playwright/test');
-const { login, getAdminCredentials, TIMEOUTS } = require('./helpers');
+const { login, getAdminCredentials, TIMEOUTS, waitForApiResponse } = require('./helpers');
 
 /**
  * Integration tests for Login functionality
@@ -14,66 +14,78 @@ test.describe('Login Integration Tests', () => {
   test.beforeEach(async ({ page }) => {
     // No mocking - tests run against real API
     // Just navigate to the page, let individual tests wait for what they need
-    await page.goto('/', { waitUntil: 'networkidle', timeout: TIMEOUTS.LONG });
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: TIMEOUTS.LONG });
   });
 
   test('should display login form', async ({ page }) => {
     // Wait for login form to be visible
-    await page.waitForSelector('input#email', { timeout: TIMEOUTS.MEDIUM });
+    const emailInput = page.getByLabel('Email');
+    await emailInput.waitFor({ state: 'visible', timeout: TIMEOUTS.MEDIUM });
     
     // Check that login form is visible
-    await expect(page.locator('h2')).toContainText('Login');
-    await expect(page.locator('input#email')).toBeVisible();
-    await expect(page.locator('input#password')).toBeVisible();
-    await expect(page.locator('button[type="submit"]')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Login' })).toBeVisible();
+    await expect(emailInput).toBeVisible();
+    await expect(page.getByLabel('Password')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Login' })).toBeVisible();
   });
 
   test('should show validation for empty fields', async ({ page }) => {
     // Wait for login form to be visible
-    await page.waitForSelector('input#email', { timeout: TIMEOUTS.MEDIUM });
+    const emailInput = page.getByLabel('Email');
+    await emailInput.waitFor({ state: 'visible', timeout: TIMEOUTS.MEDIUM });
     
     // Try to submit empty form
-    await page.click('button[type="submit"]');
+    await page.getByRole('button', { name: 'Login' }).click();
     
     // HTML5 validation should prevent submission
-    const emailInput = page.locator('input#email');
     await expect(emailInput).toHaveAttribute('required', '');
   });
 
   test('should show error for invalid credentials', async ({ page }) => {
     // Wait for login form to be visible
-    await page.waitForSelector('input#email', { timeout: TIMEOUTS.MEDIUM });
+    const emailInput = page.getByLabel('Email');
+    await emailInput.waitFor({ state: 'visible', timeout: TIMEOUTS.MEDIUM });
     
     // Fill in login form with invalid credentials
-    await page.fill('input#email', 'invalid@example.com');
-    await page.fill('input#password', 'wrongpassword');
+    await emailInput.fill('invalid@example.com');
+    await page.getByLabel('Password').fill('wrongpassword');
     
     // Submit form
-    await page.click('button[type="submit"]');
-    
-    // Wait a bit for API response
-    await page.waitForTimeout(2000);
+    const loginResponse = waitForApiResponse(page, '/api/auth/login', {
+      predicate: (response) => response.request().method() === 'POST' && response.status() >= 400,
+    });
+    await Promise.all([
+      loginResponse,
+      page.getByRole('button', { name: 'Login' }).click(),
+    ]);
     
     // Check for error message
     await expect(page.locator('.error-message')).toContainText('Invalid email or password', { timeout: TIMEOUTS.MEDIUM });
     
     // Verify we're still on login page
-    await expect(page.locator('h2')).toContainText('Login');
+    await expect(page.getByRole('heading', { name: 'Login' })).toBeVisible();
   });
 
   test('should login successfully with valid credentials', async ({ page }) => {
     // Wait for login form to be visible
-    await page.waitForSelector('input#email', { timeout: TIMEOUTS.MEDIUM });
+    const emailInput = page.getByLabel('Email');
+    await emailInput.waitFor({ state: 'visible', timeout: TIMEOUTS.MEDIUM });
     
     // Use admin credentials from helper
     const { email, password } = getAdminCredentials();
     
     // Fill in login form
-    await page.fill('input#email', email);
-    await page.fill('input#password', password);
+    await emailInput.fill(email);
+    await page.getByLabel('Password').fill(password);
     
     // Submit form
-    await page.click('button[type="submit"]');
+    const loginResponse = waitForApiResponse(page, '/api/auth/login', {
+      predicate: (response) => response.request().method() === 'POST' && response.ok(),
+    });
+    await Promise.all([
+      loginResponse,
+      page.getByRole('button', { name: 'Login' }).click(),
+    ]);
     
     // Wait for navigation and check for successful login
     await page.waitForSelector('.app-header', { state: 'visible', timeout: TIMEOUTS.LONG });
@@ -85,16 +97,16 @@ test.describe('Login Integration Tests', () => {
 
   test('should have proper input types', async ({ page }) => {
     // Wait for login form to be visible
-    await page.waitForSelector('input#email', { timeout: TIMEOUTS.MEDIUM });
+    await page.getByLabel('Email').waitFor({ state: 'visible', timeout: TIMEOUTS.MEDIUM });
     
     // Check input types
-    await expect(page.locator('input#email')).toHaveAttribute('type', 'email');
-    await expect(page.locator('input#password')).toHaveAttribute('type', 'password');
+    await expect(page.getByLabel('Email')).toHaveAttribute('type', 'email');
+    await expect(page.getByLabel('Password')).toHaveAttribute('type', 'password');
   });
 
   test('should have accessible form labels', async ({ page }) => {
     // Wait for login form to be visible
-    await page.waitForSelector('input#email', { timeout: TIMEOUTS.MEDIUM });
+    await page.getByLabel('Email').waitFor({ state: 'visible', timeout: TIMEOUTS.MEDIUM });
     
     // Check for proper labels
     const emailLabel = page.locator('label[for="email"]');

--- a/frontend/tests/integration/task-flow.spec.js
+++ b/frontend/tests/integration/task-flow.spec.js
@@ -1,5 +1,5 @@
 const { test, expect } = require('@playwright/test');
-const { login, getAdminCredentials, TIMEOUTS } = require('./helpers');
+const { login, getAdminCredentials, TIMEOUTS, waitForApiResponse } = require('./helpers');
 
 /**
  * Integration tests for complete Task workflow
@@ -15,6 +15,7 @@ test.describe('Task Management Integration Tests', () => {
     // Login before each test
     const { email, password } = getAdminCredentials();
     await login(page, email, password);
+    await page.locator('.task-list-container').waitFor({ state: 'visible', timeout: TIMEOUTS.LONG });
   });
 
   test('should display task list after login', async ({ page }) => {
@@ -30,7 +31,7 @@ test.describe('Task Management Integration Tests', () => {
     await page.waitForSelector('.task-list-header button', { state: 'visible', timeout: TIMEOUTS.LONG });
     
     // Click create task button
-    await page.click('.task-list-header button:has-text("Create Task")');
+    await page.getByRole('button', { name: 'Create Task' }).click();
     
     // Check that form is visible
     await page.waitForSelector('.task-create-form', { state: 'visible', timeout: TIMEOUTS.MEDIUM });
@@ -40,13 +41,19 @@ test.describe('Task Management Integration Tests', () => {
     const timestamp = Date.now();
     const taskName = `Integration Test Task ${timestamp}`;
     
-    await page.fill('input#name', taskName);
-    await page.fill('textarea#description', 'This is an integration test task');
-    await page.fill('input#points', '25');
-    await page.selectOption('select#frequency', 'once');
+    await page.getByLabel('Task Name').fill(taskName);
+    await page.getByLabel('Description').fill('This is an integration test task');
+    await page.getByLabel('Points').fill('25');
+    await page.getByLabel('Frequency').selectOption('once');
     
     // Submit form
-    await page.click('.task-create-form button[type="submit"]');
+    const createResponse = waitForApiResponse(page, '/api/tasks', {
+      predicate: (response) => response.request().method() === 'POST' && response.ok(),
+    });
+    await Promise.all([
+      createResponse,
+      page.getByRole('button', { name: 'Create Task' }).click(),
+    ]);
     
     // Wait for form to close
     await expect(page.locator('.task-create-form')).not.toBeVisible({ timeout: TIMEOUTS.MEDIUM });
@@ -60,30 +67,48 @@ test.describe('Task Management Integration Tests', () => {
     await page.waitForSelector('.task-list-header button', { state: 'visible', timeout: TIMEOUTS.LONG });
     
     // First, create a task
-    await page.click('.task-list-header button:has-text("Create Task")');
+    await page.getByRole('button', { name: 'Create Task' }).click();
     
     const timestamp = Date.now();
     const taskName = `Workflow Test ${timestamp}`;
     
     await page.waitForSelector('.task-create-form', { state: 'visible', timeout: TIMEOUTS.MEDIUM });
-    await page.fill('input#name', taskName);
-    await page.fill('textarea#description', 'Task for complete workflow test');
-    await page.fill('input#points', '10');
-    await page.selectOption('select#frequency', 'once');
-    await page.click('.task-create-form button[type="submit"]');
+    await page.getByLabel('Task Name').fill(taskName);
+    await page.getByLabel('Description').fill('Task for complete workflow test');
+    await page.getByLabel('Points').fill('10');
+    await page.getByLabel('Frequency').selectOption('once');
+    const createResponse = waitForApiResponse(page, '/api/tasks', {
+      predicate: (response) => response.request().method() === 'POST' && response.ok(),
+    });
+    await Promise.all([
+      createResponse,
+      page.getByRole('button', { name: 'Create Task' }).click(),
+    ]);
     
     // Wait for task to appear using filter approach for robust text matching
     const taskCard = page.locator('.task-card').filter({ hasText: taskName });
     await expect(taskCard).toBeVisible({ timeout: TIMEOUTS.LONG });
     
     // Complete the task
-    await taskCard.locator('.btn-success:has-text("Complete")').click();
+    const completeResponse = waitForApiResponse(page, '/complete', {
+      predicate: (response) => response.request().method() === 'POST' && response.ok(),
+    });
+    await Promise.all([
+      completeResponse,
+      taskCard.getByRole('button', { name: 'Complete' }).click(),
+    ]);
     
     // Wait for status to update to completed
     await expect(taskCard.locator('.status-completed')).toBeVisible({ timeout: TIMEOUTS.LONG });
     
     // As admin, approve the task
-    await taskCard.locator('.btn-primary:has-text("Approve")').click();
+    const approveResponse = waitForApiResponse(page, '/approve', {
+      predicate: (response) => response.request().method() === 'POST' && response.ok(),
+    });
+    await Promise.all([
+      approveResponse,
+      taskCard.getByRole('button', { name: 'Approve' }).click(),
+    ]);
     
     // Wait for status to update to approved
     await expect(taskCard.locator('.status-approved')).toBeVisible({ timeout: TIMEOUTS.LONG });
@@ -110,7 +135,13 @@ test.describe('Task Management Integration Tests', () => {
     await page.waitForSelector('.user-info button', { state: 'visible', timeout: TIMEOUTS.MEDIUM });
     
     // Click logout button
-    await page.click('.user-info button:has-text("Logout")');
+    const logoutResponse = waitForApiResponse(page, '/api/auth/logout', {
+      predicate: (response) => response.request().method() === 'POST',
+    });
+    await Promise.all([
+      logoutResponse,
+      page.getByRole('button', { name: 'Logout' }).click(),
+    ]);
     
     // Wait for redirect to login page
     await page.waitForSelector('h2:has-text("Login")', { state: 'visible', timeout: TIMEOUTS.LONG });
@@ -125,6 +156,7 @@ test.describe('Task List Display Integration Tests', () => {
   test.beforeEach(async ({ page }) => {
     const { email, password } = getAdminCredentials();
     await login(page, email, password);
+    await page.locator('.task-list-container').waitFor({ state: 'visible', timeout: TIMEOUTS.LONG });
   });
 
   test('should show admin buttons for completed tasks', async ({ page }) => {


### PR DESCRIPTION
### Motivation
- Reduce flakiness in integration tests that run against the real backend by waiting for API responses and using more robust, accessible locators.
- Make tests more resilient to timing/network variability in full-stack test runs that require `docker-compose`.

### Description
- Add a new helper `waitForApiResponse(page, urlFragment, options)` and export it from `frontend/tests/integration/helpers.js` for waiting on specific API responses.
- Replace fragile selectors and generic navigation waits with Playwright accessible locators like `getByLabel` and `getByRole`, and change `waitUntil` to `domcontentloaded` where appropriate.
- Use `waitForApiResponse` to synchronize on critical POSTs (login, create task, complete, approve, logout) and add explicit readiness checks for `.task-list-container` after login.
- Update `login.spec.js` and `task-flow.spec.js` to use the new helper and improved waits to stabilize the end-to-end integration flows.

### Testing
- Attempted to run integration tests with `npm run test:integration`, but the full stack could not be started because `docker`/`docker-compose` is unavailable in this environment, so tests were not executed.
- Static checks and local file updates were applied and committed, but no Playwright integration results are available due to environment limitations.
- The change is low-risk to source code and focused on test code only, and should be validated by running `npm run test:integration` against a running `docker-compose` stack.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946932b0e4083309e82127422e62bca)